### PR TITLE
The error returned by finally-block should not be ignored.

### DIFF
--- a/Classes/BFTask+PromiseLike.m
+++ b/Classes/BFTask+PromiseLike.m
@@ -52,9 +52,9 @@
     return [self continueWithExecutor:executor withBlock:^id(BFTask *task) {
         BFTask *resultTask = block();
         if (resultTask != nil) {
-            return [resultTask continueWithBlock:^id(BFTask *task2) {
+            return resultTask.then(^id(BFTask *task2) {
                 return task;
-            }];
+            });
         } else {
             return task;
         }

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ With this category, you can:
 
 * chain tasks with dot-notation as JavaScript Promise-like syntax. (no more counting brackets!)
 * write a catch block which will be called in error case only.
-* write a finally block which won't change the result value.
+* write a finally block which won't change the result value unless the block fails.
 
 ### Example
 


### PR DESCRIPTION
The error returned from `finally`-block should not be ignored.

For example, [Q's `finally`](https://github.com/kriskowal/q/tree/2d9b6ab155ec8229516d34628b9aeeda90f6b6b8#propagation) is described as:

> The final handler gets called, with no arguments, when the promise returned by `getInputPromise()` either returns a value or throws an error.  The value returned or error thrown by `getInputPromise()` passes directly to `outputPromise` unless the final handler fails, and may be delayed if the final handler returns a promise.
> 
> ``` javascript
> var outputPromise = getInputPromise()
> .fin(function () {
>     // close files, database connections, stop servers, conclude tests
> });
> ```
> -   If the handler returns a value, the value is ignored
> -   If the handler throws an error, the error passes to `outputPromise`
> -   If the handler returns a promise, `outputPromise` gets postponed.  The
>   eventual value or error has the same effect as an immediate return
>   value or thrown error: a value would be ignored, an error would be
>   forwarded.
