### PR TITLE
A block which runs regardless of success or error.

### DIFF
--- a/Classes/BFTask+PromiseLike.h
+++ b/Classes/BFTask+PromiseLike.h
@@ -36,14 +36,17 @@ typedef BFTask *(^BFPFinallyBlock)();
 
 - (BFTask *(^)(BFContinuationBlock))then;
 - (BFTask *(^)(BFContinuationBlock))catch;
+- (BFTask *(^)(BFContinuationBlock))thenOrCatch;
 - (BFTask *(^)(BFPFinallyBlock))finally;
 
 - (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOn;
 - (BFTask *(^)(BFExecutor *, BFContinuationBlock))catchOn;
+- (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOrCatchOn;
 - (BFTask *(^)(BFExecutor *, BFPFinallyBlock))finallyOn;
 
 - (BFTask *(^)(BFContinuationBlock))thenOnMain;
 - (BFTask *(^)(BFContinuationBlock))catchOnMain;
+- (BFTask *(^)(BFContinuationBlock))thenOrCatchOnMain;
 - (BFTask *(^)(BFPFinallyBlock))finallyOnMain;
 
 @end

--- a/Classes/BFTask+PromiseLike.h
+++ b/Classes/BFTask+PromiseLike.h
@@ -34,19 +34,19 @@ typedef BFTask *(^BFPFinallyBlock)();
 - (BFTask *)finallyWithExecutor:(BFExecutor *)executor withBlock:(BFPFinallyBlock)block;
 
 
+- (BFTask *(^)(BFContinuationBlock))continueWith;
 - (BFTask *(^)(BFContinuationBlock))then;
 - (BFTask *(^)(BFContinuationBlock))catch;
-- (BFTask *(^)(BFContinuationBlock))thenOrCatch;
 - (BFTask *(^)(BFPFinallyBlock))finally;
 
+- (BFTask *(^)(BFExecutor *, BFContinuationBlock))continueOn;
 - (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOn;
 - (BFTask *(^)(BFExecutor *, BFContinuationBlock))catchOn;
-- (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOrCatchOn;
 - (BFTask *(^)(BFExecutor *, BFPFinallyBlock))finallyOn;
 
+- (BFTask *(^)(BFContinuationBlock))continueOnMain;
 - (BFTask *(^)(BFContinuationBlock))thenOnMain;
 - (BFTask *(^)(BFContinuationBlock))catchOnMain;
-- (BFTask *(^)(BFContinuationBlock))thenOrCatchOnMain;
 - (BFTask *(^)(BFPFinallyBlock))finallyOnMain;
 
 @end

--- a/Classes/BFTask+PromiseLike.m
+++ b/Classes/BFTask+PromiseLike.m
@@ -61,6 +61,12 @@
     }];
 }
 
+- (BFTask *(^)(BFContinuationBlock))continueWith {
+    return ^BFTask *(BFContinuationBlock block) {
+        return [self continueWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
+    };
+}
+
 - (BFTask *(^)(BFContinuationBlock))then {
     return ^BFTask *(BFContinuationBlock block) {
         return [self thenWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
@@ -73,15 +79,15 @@
     };
 }
 
-- (BFTask *(^)(BFContinuationBlock))thenOrCatch {
-    return ^BFTask *(BFContinuationBlock block) {
-        return [self continueWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
-    };
-}
-
 - (BFTask *(^)(BFPFinallyBlock))finally; {
     return ^BFTask *(BFPFinallyBlock block) {
         return [self finallyWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
+    };
+}
+
+- (BFTask *(^)(BFExecutor *, BFContinuationBlock))continueOn {
+    return ^BFTask *(BFExecutor *executor, BFContinuationBlock block) {
+        return [self continueWithExecutor:executor withBlock:block];
     };
 }
 
@@ -97,15 +103,15 @@
     };
 }
 
-- (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOrCatchOn {
-    return ^BFTask *(BFExecutor *executor, BFContinuationBlock block) {
-        return [self continueWithExecutor:executor withBlock:block];
-    };
-}
-
 - (BFTask *(^)(BFExecutor *, BFPFinallyBlock))finallyOn {
     return ^BFTask *(BFExecutor *executor, BFPFinallyBlock block) {
         return [self finallyWithExecutor:executor withBlock:block];
+    };
+}
+
+- (BFTask *(^)(BFContinuationBlock))continueOnMain {
+    return ^BFTask *(BFContinuationBlock block) {
+        return [self continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
     };
 }
 
@@ -118,12 +124,6 @@
 - (BFTask *(^)(BFContinuationBlock))catchOnMain {
     return ^BFTask *(BFContinuationBlock block) {
         return [self catchWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
-    };
-}
-
-- (BFTask *(^)(BFContinuationBlock))thenOrCatchOnMain {
-    return ^BFTask *(BFContinuationBlock block) {
-        return [self continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
     };
 }
 

--- a/Classes/BFTask+PromiseLike.m
+++ b/Classes/BFTask+PromiseLike.m
@@ -73,6 +73,12 @@
     };
 }
 
+- (BFTask *(^)(BFContinuationBlock))thenOrCatch {
+    return ^BFTask *(BFContinuationBlock block) {
+        return [self continueWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
+    };
+}
+
 - (BFTask *(^)(BFPFinallyBlock))finally; {
     return ^BFTask *(BFPFinallyBlock block) {
         return [self finallyWithExecutor:[BFExecutor defaultExecutor] withBlock:block];
@@ -91,6 +97,12 @@
     };
 }
 
+- (BFTask *(^)(BFExecutor *, BFContinuationBlock))thenOrCatchOn {
+    return ^BFTask *(BFExecutor *executor, BFContinuationBlock block) {
+        return [self continueWithExecutor:executor withBlock:block];
+    };
+}
+
 - (BFTask *(^)(BFExecutor *, BFPFinallyBlock))finallyOn {
     return ^BFTask *(BFExecutor *executor, BFPFinallyBlock block) {
         return [self finallyWithExecutor:executor withBlock:block];
@@ -106,6 +118,12 @@
 - (BFTask *(^)(BFContinuationBlock))catchOnMain {
     return ^BFTask *(BFContinuationBlock block) {
         return [self catchWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
+    };
+}
+
+- (BFTask *(^)(BFContinuationBlock))thenOrCatchOnMain {
+    return ^BFTask *(BFContinuationBlock block) {
+        return [self continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
     };
 }
 

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,8 @@ With this category, you can:
 ### Example
 
 ```objc
-[self countUsersAsync].then(^id(BFTask *task) {
+[self countUsersAsync].continueWith(^id(BFTask *task) {
+    // this block is called regardless of the success or failure
     NSNumber *count = task.result;
     if ([count intValue] <= 0) {
         return [BFTask taskWithError:[NSError errorWithDomain:@"MyDomain"
@@ -24,7 +25,7 @@ With this category, you can:
         return [self makeTotalUserStringAsync:count];
     }
 }).then(^id(BFTask *task) {
-    // this block is skipped when task is failed.
+    // this block is skipped when the previous task is failed.
     [self showMessage:task.result];
     return nil;
 }).catch(^id(BFTask *task) {
@@ -39,8 +40,8 @@ With this category, you can:
 
 ### Executors
 
-If you want to specify the executor, use `thenOn`, `catchOn` and `finallyOn`.
-You can also use `thenOnMain`, `catchOnMain` and `finallyOnMain`, they use `mainThreadExecutor`. 
+If you want to specify the executor, use `continueOn`, `thenOn`, `catchOn` and `finallyOn`.
+You can also use `continueOnMain`, `thenOnMain`, `catchOnMain` and `finallyOnMain`, they use `mainThreadExecutor`. 
 
 ```objc
 [User findAllAsync].catchOn([BFExecutor mainThreadExecutor], ^id(BFTask *task) {


### PR DESCRIPTION
In issue #2, @felix-dumit would want a block to run regardless of success or error.
Since `BFTask` originally has `continueWithBlock:`, I can write a dot-notation wrapper.
Although I don't like the name `thenOrCatch` so much.:confused:
Opinions?
